### PR TITLE
Prevent blank screen from spoofing premium status

### DIFF
--- a/Source/PremiumStatus.xm
+++ b/Source/PremiumStatus.xm
@@ -191,6 +191,14 @@
     return YES;
 }
 %end
+
+%hook YTUserDefaults
+
+- (BOOL)hasOnboarded {
+    return YES;
+}
+
+%end
 %end
 
 %ctor {


### PR DESCRIPTION
I believe spoofing premium status causes the onboarding page response to be blank because the user isn't actually a premium user and that response is for premium only.

Closes #54 