### PR TITLE
Fix for CI build issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,12 +94,13 @@ jobs:
       - name: Download YouTube Music
         id: download_youtube_music
         run: wget "${{ inputs.ipa_url }}" --no-verbose -O ${{ github.workspace }}/main/ytm.ipa
-
+      
       - name: Build Tweak for Sideloading
-        id: build_package
         run: |
           cd ${{ github.workspace }}/main
-          make clean package SIDELOADING=1 ADDITIONAL_OBJCXXFLAGS="-Wno-error=vla-cxx-extension"
+          make clean package SIDELOADING=1 WERROR=0 \
+            ADDITIONAL_OBJCXXFLAGS="-Wno-vla-cxx-extension -Wno-error=vla-cxx-extension" \
+            ADDITIONAL_CFLAGS="-Wno-vla -Wno-error=vla"
         env:
           THEOS: ${{ github.workspace }}/theos
 


### PR DESCRIPTION
Build fails on macos-latest with:

==> Compiling Source/AVSwitching.xm (arm64)… Source/SponsorBlock.xm:112:534: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]


This fix will allow the build on macos-latest