### PR TITLE
Fix main.yml compilation errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,13 @@ concurrency:
 jobs:
   build:
     name: Build YTMusicUltimate
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: write
 
     steps:
       - name: Checkout Main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v5
         with:
           path: main
           submodules: recursive
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache Theos
         id: theos
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4.3.0
         env:
           cache-name: theos_cache_67db2ab
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup Theos
         if: steps.theos.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v5
         with:
           repository: theos/theos
           ref: 67db2ab8d950910161730de77c322658ea3e6b44
@@ -111,7 +111,7 @@ jobs:
           cyan -i ytm.ipa -o packages/YTMusicUltimate.ipa -uwsf packages/$tweakName -n "${{ inputs.display_name }}" -b ${{ inputs.bundle_id }} 
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2.0.6
+        uses: softprops/action-gh-release@v2.4.1
         with:
           name: YTMusicUltimate-v${{ github.run_number }}
           files: main/packages/*.ipa


### PR DESCRIPTION
Main cause: `macos-latest` runner was causing a ton of errors so it’s been switched over to `macos-14` runner.

other changes: updated dependencies.