### PR TITLE
Fix download action crash on latest YouTube Music

### DIFF
--- a/Source/Downloading.x
+++ b/Source/Downloading.x
@@ -18,6 +18,138 @@ static BOOL YTMU(NSString *key) {
     return [YTMUltimateDict[key] boolValue];
 }
 
+static id YTMUDownloadSafeValueForKey(id object, NSString *key) {
+    if (!object || !key.length) return nil;
+    @try {
+        return [object valueForKey:key];
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static YTPlayerViewController *YTMUDownloadPlayerFromObject(id candidate, NSUInteger depth);
+
+static YTPlayerViewController *YTMUDownloadPlayerFromKnownKeys(id candidate, NSUInteger depth) {
+    NSArray<NSString *> *keys = @[
+        @"playerViewController",
+        @"_playerViewController",
+        @"playerViewDelegate",
+        @"_playerViewDelegate",
+        @"playerController",
+        @"_playerController",
+        @"player",
+        @"_player"
+    ];
+    for (NSString *key in keys) {
+        id value = YTMUDownloadSafeValueForKey(candidate, key);
+        if (!value || value == candidate) continue;
+        YTPlayerViewController *player = YTMUDownloadPlayerFromObject(value, depth + 1);
+        if (player) return player;
+    }
+    return nil;
+}
+
+static YTPlayerViewController *YTMUDownloadPlayerFromObject(id candidate, NSUInteger depth) {
+    if (!candidate || depth > 10) return nil;
+
+    Class playerClass = NSClassFromString(@"YTPlayerViewController");
+    if (playerClass && [candidate isKindOfClass:playerClass]) return candidate;
+
+    YTPlayerViewController *keyPlayer = YTMUDownloadPlayerFromKnownKeys(candidate, depth);
+    if (keyPlayer) return keyPlayer;
+
+    id parent = YTMUDownloadSafeValueForKey(candidate, @"parentViewController");
+    if (parent && parent != candidate) {
+        YTPlayerViewController *parentPlayer = YTMUDownloadPlayerFromObject(parent, depth + 1);
+        if (parentPlayer) return parentPlayer;
+    }
+
+    if ([candidate isKindOfClass:[UIViewController class]]) {
+        UIViewController *viewController = (UIViewController *)candidate;
+        YTPlayerViewController *viewPlayer = YTMUDownloadPlayerFromObject(viewController.view, depth + 1);
+        if (viewPlayer) return viewPlayer;
+
+        for (UIViewController *child in viewController.childViewControllers) {
+            YTPlayerViewController *childPlayer = YTMUDownloadPlayerFromObject(child, depth + 1);
+            if (childPlayer) return childPlayer;
+        }
+    }
+
+    return nil;
+}
+
+static YTPlayerViewController *YTMUDownloadPlayerFromViewHierarchy(UIView *view) {
+    for (UIView *ancestor = view; ancestor; ancestor = ancestor.superview) {
+        YTPlayerViewController *player = YTMUDownloadPlayerFromObject(ancestor, 0);
+        if (player) return player;
+    }
+    return nil;
+}
+
+static YTPlayerViewController *YTMUDownloadPlayerInSubviews(UIView *view, NSUInteger depth) {
+    if (!view || depth > 8) return nil;
+
+    YTPlayerViewController *player = YTMUDownloadPlayerFromObject(view, 0);
+    if (player) return player;
+
+    for (UIView *subview in view.subviews) {
+        YTPlayerViewController *subviewPlayer = YTMUDownloadPlayerInSubviews(subview, depth + 1);
+        if (subviewPlayer) return subviewPlayer;
+    }
+    return nil;
+}
+
+static id YTMUDownloadPlayerResponseFromObject(id candidate, NSUInteger depth) {
+    if (!candidate || depth > 10) return nil;
+
+    id response = YTMUDownloadSafeValueForKey(candidate, @"playerResponse") ?: YTMUDownloadSafeValueForKey(candidate, @"_playerResponse");
+    if (response) return response;
+
+    id parentResponder = YTMUDownloadSafeValueForKey(candidate, @"parentResponder") ?: YTMUDownloadSafeValueForKey(candidate, @"_parentResponder");
+    if (parentResponder && parentResponder != candidate) {
+        id parentResponse = YTMUDownloadPlayerResponseFromObject(parentResponder, depth + 1);
+        if (parentResponse) return parentResponse;
+    }
+
+    id delegate = YTMUDownloadSafeValueForKey(candidate, @"delegate") ?: YTMUDownloadSafeValueForKey(candidate, @"_delegate");
+    if (delegate && delegate != candidate) {
+        id delegateResponse = YTMUDownloadPlayerResponseFromObject(delegate, depth + 1);
+        if (delegateResponse) return delegateResponse;
+    }
+
+    if ([candidate isKindOfClass:[UIViewController class]]) {
+        UIViewController *viewController = (UIViewController *)candidate;
+        for (UIViewController *child in viewController.childViewControllers) {
+            id childResponse = YTMUDownloadPlayerResponseFromObject(child, depth + 1);
+            if (childResponse) return childResponse;
+        }
+    }
+
+    return nil;
+}
+
+static id YTMUDownloadObjectForKey(id object, NSString *key) {
+    if (!object || !key.length) return nil;
+    if ([object isKindOfClass:[NSDictionary class]]) return ((NSDictionary *)object)[key];
+    return YTMUDownloadSafeValueForKey(object, key);
+}
+
+static NSString *YTMUDownloadStringForKey(id object, NSString *key) {
+    id value = YTMUDownloadObjectForKey(object, key);
+    if ([value isKindOfClass:[NSString class]]) return value;
+    if ([value respondsToSelector:@selector(stringValue)]) return [value stringValue];
+    return @"";
+}
+
+static NSString *YTMUDownloadSanitizeFileComponent(NSString *string) {
+    NSString *safe = string.length ? string : @"Unknown";
+    NSArray<NSString *> *bad = @[@"/", @":", @"\n", @"\r"];
+    for (NSString *part in bad) {
+        safe = [safe stringByReplacingOccurrencesOfString:part withString:@""];
+    }
+    return safe;
+}
+
 @interface UIView ()
 - (UIViewController *)_viewControllerForAncestor;
 @end
@@ -52,11 +184,13 @@ static BOOL YTMU(NSString *key) {
     }
 
     YTMNowPlayingViewController *playingVC = (YTMNowPlayingViewController *)tapRecognizer.view._viewControllerForAncestor;
-    YTMWatchViewController *watchVC = (YTMWatchViewController *)playingVC.parentViewController;
-    YTPlayerViewController *playerVC = watchVC.playerViewController;
-    YTPlayerResponse *playerResponse = playerVC.playerResponse;
+    YTPlayerViewController *playerVC = YTMUDownloadPlayerFromViewHierarchy(tapRecognizer.view);
+    if (!playerVC) playerVC = YTMUDownloadPlayerFromObject(playingVC, 0);
+    if (!playerVC) playerVC = YTMUDownloadPlayerInSubviews(playingVC.view, 0);
+    if (!playerVC) playerVC = YTMUDownloadPlayerFromObject([UIApplication sharedApplication].keyWindow.rootViewController, 0);
+    id playerResponse = YTMUDownloadPlayerResponseFromObject(playerVC, 0);
 
-    if (playerResponse) {
+    if (playerVC && playerResponse) {
         YTMActionSheetController *sheetController = [%c(YTMActionSheetController) musicActionSheetController];
         sheetController.sourceView = tapRecognizer.view;
         [sheetController addHeaderWithTitle:LOC(@"SELECT_ACTION") subtitle:nil];
@@ -90,16 +224,27 @@ static BOOL YTMU(NSString *key) {
 
 %new
 - (void)downloadAudio:(YTPlayerViewController *)playerVC {
-    YTPlayerResponse *playerResponse = playerVC.playerResponse;
+    id playerResponse = YTMUDownloadPlayerResponseFromObject(playerVC, 0);
+    if (!playerResponse) {
+        YTAlertView *alertView = [%c(YTAlertView) infoDialog];
+        alertView.title = LOC(@"OOPS");
+        alertView.subtitle = LOC(@"LINK_NOT_FOUND");
+        [alertView show];
+        return;
+    }
 
-    NSString *title = [playerResponse.playerData.videoDetails.title stringByReplacingOccurrencesOfString:@"/" withString:@""];
-    NSString *author = [playerResponse.playerData.videoDetails.author stringByReplacingOccurrencesOfString:@"/" withString:@""];
-    NSString *urlStr = playerResponse.playerData.streamingData.hlsManifestURL;
+    id playerData = YTMUDownloadObjectForKey(playerResponse, @"playerData");
+    id videoDetails = YTMUDownloadObjectForKey(playerData, @"videoDetails");
+    id streamingData = YTMUDownloadObjectForKey(playerData, @"streamingData");
+    NSString *title = YTMUDownloadSanitizeFileComponent(YTMUDownloadStringForKey(videoDetails, @"title"));
+    NSString *author = YTMUDownloadSanitizeFileComponent(YTMUDownloadStringForKey(videoDetails, @"author"));
+    NSString *urlStr = YTMUDownloadStringForKey(streamingData, @"hlsManifestURL");
 
     FFMpegDownloader *ffmpeg = [[FFMpegDownloader alloc] init];
-    ffmpeg.tempName = playerVC.contentVideoID;
+    ffmpeg.tempName = YTMUDownloadStringForKey(playerVC, @"contentVideoID");
     ffmpeg.mediaName = [NSString stringWithFormat:@"%@ - %@", author, title];
-    ffmpeg.duration = round(playerVC.currentVideoTotalMediaTime);
+    id durationValue = YTMUDownloadObjectForKey(playerVC, @"currentVideoTotalMediaTime");
+    ffmpeg.duration = [durationValue respondsToSelector:@selector(doubleValue)] ? round([durationValue doubleValue]) : 0;
 
     
     NSString *extractedURL = [self getURLFromManifest:[NSURL URLWithString:urlStr]];
@@ -107,7 +252,8 @@ static BOOL YTMU(NSString *key) {
     if (extractedURL.length > 0) {
         [ffmpeg downloadAudio:extractedURL];
 
-        NSMutableArray *thumbnailsArray = playerResponse.playerData.videoDetails.thumbnail.thumbnailsArray;
+        id thumbnailDetails = YTMUDownloadObjectForKey(videoDetails, @"thumbnail");
+        NSMutableArray *thumbnailsArray = YTMUDownloadObjectForKey(thumbnailDetails, @"thumbnailsArray");
         YTIThumbnailDetails_Thumbnail *thumbnail = [thumbnailsArray lastObject];
         NSData *imageData = [NSData dataWithContentsOfURL:[NSURL URLWithString:thumbnail.URL]];
 
@@ -156,9 +302,22 @@ static BOOL YTMU(NSString *key) {
         hud.mode = MBProgressHUDModeIndeterminate;
     });
 
-    YTPlayerResponse *playerResponse = playerVC.playerResponse;
+    id playerResponse = YTMUDownloadPlayerResponseFromObject(playerVC, 0);
+    if (!playerResponse) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [hud hideAnimated:YES];
+        });
+        YTAlertView *alertView = [%c(YTAlertView) infoDialog];
+        alertView.title = LOC(@"OOPS");
+        alertView.subtitle = LOC(@"LINK_NOT_FOUND");
+        [alertView show];
+        return;
+    }
 
-    NSMutableArray *thumbnailsArray = playerResponse.playerData.videoDetails.thumbnail.thumbnailsArray;
+    id playerData = YTMUDownloadObjectForKey(playerResponse, @"playerData");
+    id videoDetails = YTMUDownloadObjectForKey(playerData, @"videoDetails");
+    id thumbnailDetails = YTMUDownloadObjectForKey(videoDetails, @"thumbnail");
+    NSMutableArray *thumbnailsArray = YTMUDownloadObjectForKey(thumbnailDetails, @"thumbnailsArray");
     YTIThumbnailDetails_Thumbnail *thumbnail = [thumbnailsArray lastObject];
     NSString *thumbnailURL = [thumbnail.URL stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"w%u-h%u-", thumbnail.width, thumbnail.width] withString:@"w2048-h2048-"];
 


### PR DESCRIPTION
## Summary

Tapping **Download** on the latest YouTube Music build crashes the app with an unrecognized selector exception. The hook calls `-[YTPlayerViewController playerResponse]` directly, but the new build has moved that property into a child overlay/controller — the player view controller no longer responds to the selector.

This PR keeps the existing control flow of `handleTap` exactly as upstream had it, and only changes the part that crashes: resolving `playerVC` and `playerResponse` is now done by walking the player / overlay / controller hierarchy via KVC, falling back gracefully when nothing can be located. The toggles, the action sheet, the `DONT_RUSH` alert path, and the silent exit when both toggles are off are all preserved unchanged.

Closes #440.

## What changed

- `Source/Downloading.x` only.
- Added self-contained static helpers (`YTMUDownloadPlayerFromObject`, `YTMUDownloadPlayerResponseFromObject`, etc.) that traverse the view-controller / responder / delegate / child hierarchy to find the player VC and its `playerResponse`.
- `handleTap` now uses those helpers in place of the brittle `playingVC.parentViewController.playerViewController.playerResponse` chain. The conditional structure underneath (`if (playerResponse) { build sheet; toggle-based dispatch } else { DONT_RUSH alert }`) is unchanged.
- `downloadAudio:` and `downloadCoverImage:` (cover-image hook) read the nested `playerResponse` fields through KVC and bail with a `LINK_NOT_FOUND` alert instead of crashing if the response cannot be reached.
- The Premium native download item (`DOWNLOAD_PREMIUM` action) is unaffected.
- No other files touched; no new dependencies; no behaviour change when both `downloadAudio` and `downloadCoverImage` toggles are off (the existing toggle-driven branches at the bottom of `handleTap` already exit silently in that case, identically to upstream).

## Test plan

- [x] Built locally with `THEOS=… make clean package` — clean compile.
- [x] Sideloaded onto a device running the affected YouTube Music build with `downloadAudio` enabled. Tapping **Download** now opens the action sheet and the audio download completes successfully (previously this crashed the app).
- [x] With both `downloadAudio` and `downloadCoverImage` off, tapping **Download** is silent — matching upstream's intended behaviour (when both toggles are off, none of the bottom branches in `handleTap` fire). No regression observed.
- [ ] `playerResponse` not resolvable → `LINK_NOT_FOUND` alert. Not exercised dynamically; covered by code inspection — every dereference is guarded with KVC `@try`/`@catch` and the early-bail alert is now in both `downloadAudio:` and `downloadCoverImage:`.