### PR TITLE
Fix volume bar source not being compiled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ PACKAGE_VERSION = 2.4.1
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = YTMusicUltimate
-$(TWEAK_NAME)_FILES = $(filter-out Source/Sideloading.x, $(wildcard Source/*.x))
-$(TWEAK_NAME)_FILES += $(shell find Source -name '*.m')
+$(TWEAK_NAME)_FILES = $(filter-out Source/Sideloading.x, $(shell find Source \( -name '*.x' -o -name '*.xm' -o -name '*.m' \)))
 $(TWEAK_NAME)_CFLAGS = -fobjc-arc -Wno-deprecated-declarations -DTWEAK_VERSION=$(PACKAGE_VERSION)
 $(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation AVFoundation AudioToolbox VideoToolbox
 $(TWEAK_NAME)_OBJ_FILES = $(shell find Source/Utils/lib -name '*.a')


### PR DESCRIPTION
## Summary

The Player Options volume bar toggle does not show the volume bar because the hook file is no longer included in the tweak build.

`Source/VolumeBar/VolumeBar.xm` contains the `%hook YTMWatchView` code that creates and lays out the volume bar, but the current Makefile only includes top-level `Source/*.x` files plus Objective-C `.m` files. As a result, `GSVolBar.m` is compiled, but the hook that adds it to the player view is left out of the dylib.

This PR restores recursive source discovery for `.x`, `.xm`, and `.m` files under `Source`, while still excluding `Source/Sideloading.x` unless `SIDELOADING=1`.

## What changed

- `Makefile` only.
- Replaced the top-level `$(wildcard Source/*.x)` + recursive `.m` collection with one recursive `find` that includes `.x`, `.xm`, and `.m`.
- Kept `Source/Sideloading.x` excluded from normal builds, preserving the existing `SIDELOADING=1` behavior.
- No runtime hook logic changed.

## Test plan

- [x] Built locally with `THEOS=… make clean package` — clean compile.
- [x] Confirmed the build now preprocesses and compiles `Source/VolumeBar/VolumeBar.xm`.
- [x] Sideloaded the same fix in my local build and confirmed the volume bar appears again when enabled.
- [x] Verified the PR branch only changes `Makefile`.